### PR TITLE
removed -1 measurements from the hour average for dashboard

### DIFF
--- a/aqandu_data_access_api_py3/influx/influx.py
+++ b/aqandu_data_access_api_py3/influx/influx.py
@@ -231,6 +231,7 @@ def get_data():
 
         # hour Averaging
         if hourAvg:
+            dff = dff.replace(-1, np.nan)
             dff = dff.resample('H').mean()
             avg_str = '_HR-AVG'
         else:


### PR DESCRIPTION
(-1) PM measurements, which signify bad data, were being used in the hour average, giving an untrue average for the hour. They are now converted to NaN values before the hour averaging is performed so that they are not included in the average. 